### PR TITLE
makefile: fix TF-A path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,12 @@
 #
 
 RECOVERY ?= 0
-ARM_TRUSTED_FIRMWARE ?= ../arm-trusted-firmware/
-ARM_TF_INCLUDE ?= $(ARM_TRUSTED_FIRMWARE)/plat/hisilicon/poplar/include
+
+ifndef TF_A_PATH
+TF_A_PATH ?= ../trusted-firmware-a/
+endif
+
+TF_A_INCLUDE ?= $(TF_A_PATH)/plat/hisilicon/poplar/include
 
 # Must use a 32-bit ARM cross-compiler
 CROSS_COMPILE ?= arm-linux-gnueabihf-
@@ -67,14 +71,14 @@ l-loader: start.o debug.o l-loader.lds
 	$(LD) -Bstatic -Tl-loader.lds start.o debug.o -o $@
 
 start.o: start.S
-	$(CC) -c -o $@ $< -I$(ARM_TF_INCLUDE) -DVERSION_MSG=$(VERSION_MSG) \
+	$(CC) -c -o $@ $< -I$(TF_A_INCLUDE) -DVERSION_MSG=$(VERSION_MSG) \
 		$(CFLAGS)
 
 start.S: atf/bl1.bin atf/fip.bin
 
 atf/bl1.bin atf/fip.bin:
 	@echo ""
-	@echo "Error: \"$@\" is missing; it must be built from ARM-TF"
+	@echo "Error: \"$@\" is missing; it must be built from TF-A"
 	@echo ""
 	@false
 
@@ -82,7 +86,7 @@ debug.o: debug.S
 	$(CC) -c -o $@ $<
 
 l-loader.lds: l-loader.ld.in
-	$(CPP) -P -o $@ - < $< -I$(ARM_TF_INCLUDE) $(CFLAGS)
+	$(CPP) -P -o $@ - < $< -I$(TF_A_INCLUDE) $(CFLAGS)
 
 clean:
 	@rm -f *.o l-loader.lds l-loader l-loader.bin fastboot.bin \


### PR DESCRIPTION
1. Rename ARM Trusted Firmware to Trusted Firmware A
2. Add support of providing TF-A path as external param for make

`Signed-off-by: Igor Opaniuk <igor.opaniuk@gmail.com>`